### PR TITLE
BlockHeader Updates

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/first-interaction@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        pr-message: 'Congrats, you just opened your first pull request on libsv/libsv! Thank you for contributing!'
+        pr-message: 'Congrats, you just opened your first pull request on libsv/go-bc! Thank you for contributing!'

--- a/blockheader_test.go
+++ b/blockheader_test.go
@@ -36,7 +36,7 @@ func TestDecodeBlockHeader(t *testing.T) {
 	}
 	expectedHeader := "00000020fb9eacea87c1cc294a4f1633a45b9bfb21cf9878b439c6138d96b8ca3a856e3a37307cd123724eaa4ade23d29feea1358458d5c110275b6cca4e2b79cd14d98e39573460ffff7f2000000000"
 
-	headerBytes, err := bc.DecodeBlockHeader(bh)
+	headerBytes, err := bh.Bytes()
 	header := hex.EncodeToString(headerBytes)
 
 	assert.NoError(t, err)

--- a/blockheaderchain.go
+++ b/blockheaderchain.go
@@ -1,10 +1,34 @@
 package bc
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrHeaderNotFound can be returned if the blockHash isn't found on the network.
+	ErrHeaderNotFound = errors.New("header with not found")
+	// ErrNotOnLongestChain indicates the blockhash is present but isn't on the longest current chain.
+	ErrNotOnLongestChain = errors.New("header exists but is not on the longest chain")
+)
 
 // A BlockHeaderChain is a generic interface used to map things in the block header chain
 // (chain of block headers). For example, it is used to get a block Header from a bitcoin
 // block hash if it exists in the longest block header chain.
+//
+// Errors can be returned if the header isn't found or is on a stale chain, you may also use the
+// ErrHeaderNotFound & ErrNotOnLongestChain sentinel errors when implementing the interface.
 type BlockHeaderChain interface {
-	BlockHeader(ctx context.Context, blockHash string) (blockHeader string, err error)
+	BlockHeader(ctx context.Context, blockHash string) (*BlockHeader, error)
+}
+
+// A BlockHeaderChainStringer is a generic interface used to map things in the block header chain
+// (chain of block headers). For example, it is used to get a block Header from a bitcoin
+// block hash if it exists in the longest block header chain.
+// This will return the blockheader hash as a string.
+//
+// Errors can be returned if the header isn't found or is on a stale chain, you may also use the
+// ErrHeaderNotFound & ErrNotOnLongestChain sentinel errors when implementing the interface.
+type BlockHeaderChainStringer interface {
+	BlockHeaderHash(ctx context.Context, blockHash string) (blockHeader string, err error)
 }

--- a/blockheaderchain.go
+++ b/blockheaderchain.go
@@ -21,14 +21,3 @@ var (
 type BlockHeaderChain interface {
 	BlockHeader(ctx context.Context, blockHash string) (*BlockHeader, error)
 }
-
-// A BlockHeaderChainStringer is a generic interface used to map things in the block header chain
-// (chain of block headers). For example, it is used to get a block Header from a bitcoin
-// block hash if it exists in the longest block header chain.
-// This will return the blockheader hash as a string.
-//
-// Errors can be returned if the header isn't found or is on a stale chain, you may also use the
-// ErrHeaderNotFound & ErrNotOnLongestChain sentinel errors when implementing the interface.
-type BlockHeaderChainStringer interface {
-	BlockHeaderHash(ctx context.Context, blockHash string) (blockHeader string, err error)
-}

--- a/spvclient.go
+++ b/spvclient.go
@@ -1,20 +1,78 @@
 package bc
 
+import (
+	"context"
+	"errors"
+)
+
 // An SPVClient is a struct used to specify interfaces
 // used to complete Simple Payment Verification (SPV)
 // in conjunction with a Merkle Proof.
+//
+// The implementation of BlockHeaderChain which is supplied will depend on the client
+// you are using, some may return a HeaderJSON response others may return the blockhash.
 type SPVClient struct {
+	// BlockHeaderChain will be set when an implementation returning a bc.BlockHeader type is provided.
 	bhc BlockHeaderChain
+	// BlockHeaderChainStringer will be set when an implementation returning a block header hash is provided.
+	bhchash BlockHeaderChainStringer
 }
 
-// NewSPVClient creates a new SPVClient based on params
-// passed or will use defaults if nil is passed.
-func NewSPVClient(bhc BlockHeaderChain) *SPVClient {
-	if bhc == nil {
-		return &SPVClient{}
-	}
+// SPVOpts can be implemented to provided functional options for an SPVClient.
+type SPVOpts func(*SPVClient)
 
-	return &SPVClient{
-		bhc: bhc,
+// WithBlockHeaderChain will inject the provided BlockHeaderChain into the SPVClient.
+func WithBlockHeaderChain(bhc BlockHeaderChain) SPVOpts {
+	return func(s *SPVClient) {
+		s.bhc = bhc
 	}
+}
+
+// WithBlockHeaderChainStringer will inject the provided BlockHeaderChainStringer into the SPVClient.
+func WithBlockHeaderChainStringer(bhc BlockHeaderChainStringer) SPVOpts {
+	return func(s *SPVClient) {
+		s.bhchash = bhc
+	}
+}
+
+// NewSPVClient creates a new SPVClient based on the options provided.
+// If no BlockHeaderChain implementation is provided, the setup will return an error.
+// If both a BlockHeaderChain AND a WithBlockHeaderChainStringer are provided it will
+// attempt to use BlockHeaderChain first before falling back to the WithBlockHeaderChainStringer
+// in the event of an error.
+func NewSPVClient(opts ...SPVOpts) (*SPVClient, error) {
+	cli := &SPVClient{}
+	for _, opt := range opts {
+		opt(cli)
+	}
+	if cli.bhc == nil && cli.bhchash == nil {
+		return nil, errors.New("at least one blockchain header implementation should be returned")
+	}
+	return cli, nil
+}
+
+// BlockHeader will return the block header using the client implementation provided to the SPVClient.
+func (spvc *SPVClient) BlockHeader(ctx context.Context, blockHash string) (*BlockHeader, error) {
+	if spvc.bhc == nil && spvc.bhchash == nil {
+		return nil, errors.New("no BlockHeaderChain implementation provided, setup the SPVClient with at least one")
+	}
+	// try the strong typed version first.
+	var err error
+	if spvc.bhc != nil {
+		bh, e := spvc.bhc.BlockHeader(ctx, blockHash)
+		if e == nil {
+			return bh, nil
+		}
+		err = e
+	}
+	// if strong typed failed, or isn't set, try the hash version, which will then convert to a
+	// strong typed bc.BlockHeader
+	if spvc.bhchash != nil {
+		bh, e := spvc.bhchash.BlockHeaderHash(ctx, blockHash)
+		if e == nil {
+			return EncodeBlockHeaderStr(bh)
+		}
+		err = e
+	}
+	return nil, err
 }

--- a/spvclient.go
+++ b/spvclient.go
@@ -27,9 +27,6 @@ func WithBlockHeaderChain(bhc BlockHeaderChain) SPVOpts {
 
 // NewSPVClient creates a new SPVClient based on the options provided.
 // If no BlockHeaderChain implementation is provided, the setup will return an error.
-// If both a BlockHeaderChain AND a WithBlockHeaderChainStringer are provided it will
-// attempt to use BlockHeaderChain first before falling back to the WithBlockHeaderChainStringer
-// in the event of an error.
 func NewSPVClient(opts ...SPVOpts) (*SPVClient, error) {
 	cli := &SPVClient{}
 	for _, opt := range opts {

--- a/verifymerkleproof.go
+++ b/verifymerkleproof.go
@@ -42,16 +42,12 @@ func (spvc *SPVClient) VerifyMerkleProof(ctx context.Context, proof []byte) (val
 	// if bits 1 and 2 of flags are NOT set, target should contain a block hash (32 bytes)
 	case 0:
 		// The `target` field contains a block hash
-
-		blockHeader, err := spvc.bhc.BlockHeader(ctx, mpb.target)
+		blockHeader, err := spvc.BlockHeader(ctx, mpb.target)
 		if err != nil {
 			return false, false, err
 		}
 
-		merkleRoot, err = ExtractMerkleRootFromBlockHeader(blockHeader)
-		if err != nil {
-			return false, false, err
-		}
+		merkleRoot = blockHeader.HashMerkleRoot
 
 	// if bit 2 of flags is set, target should contain a merkle root (32 bytes)
 	case 4:
@@ -106,15 +102,11 @@ func (spvc *SPVClient) VerifyMerkleProofJSON(ctx context.Context, proof *MerkleP
 			return false, false, errors.New("invalid target field")
 		}
 
-		blockHeader, err := spvc.bhc.BlockHeader(ctx, proof.Target)
+		blockHeader, err := spvc.BlockHeader(ctx, proof.Target)
 		if err != nil {
 			return false, false, err
 		}
-
-		merkleRoot, err = ExtractMerkleRootFromBlockHeader(blockHeader)
-		if err != nil {
-			return false, false, err
-		}
+		merkleRoot = blockHeader.HashMerkleRoot
 
 	} else if proof.TargetType == "header" && len(proof.Target) == 160 {
 		// The `target` field contains a block header

--- a/verifymerkleproof.go
+++ b/verifymerkleproof.go
@@ -42,7 +42,7 @@ func (spvc *SPVClient) VerifyMerkleProof(ctx context.Context, proof []byte) (val
 	// if bits 1 and 2 of flags are NOT set, target should contain a block hash (32 bytes)
 	case 0:
 		// The `target` field contains a block hash
-		blockHeader, err := spvc.BlockHeader(ctx, mpb.target)
+		blockHeader, err := spvc.bhc.BlockHeader(ctx, mpb.target)
 		if err != nil {
 			return false, false, err
 		}
@@ -102,7 +102,7 @@ func (spvc *SPVClient) VerifyMerkleProofJSON(ctx context.Context, proof *MerkleP
 			return false, false, errors.New("invalid target field")
 		}
 
-		blockHeader, err := spvc.BlockHeader(ctx, proof.Target)
+		blockHeader, err := spvc.bhc.BlockHeader(ctx, proof.Target)
 		if err != nil {
 			return false, false, err
 		}

--- a/verifymerkleproof_test.go
+++ b/verifymerkleproof_test.go
@@ -10,10 +10,8 @@ import (
 
 type mockBlockHeaderChain struct{}
 
-func (bhc *mockBlockHeaderChain) BlockHeader(ctx context.Context, blockHash string) (blockHeader string, err error) {
-	return map[string]string{
-		"75edb0a69eb195cdd81e310553aa4d25e18450e08f168532a2c2e9cf447bf169": "000000208e33a53195acad0ab42ddbdbe3e4d9ca081332e5b01a62e340dbd8167d1a787b702f61bb913ac2063e0f2aed6d933d3386234da5c8eb9e30e498efd25fb7cb96fff12c60ffff7f2001000000",
-	}[blockHash], nil
+func (bhc *mockBlockHeaderChain) BlockHeader(ctx context.Context, blockHash string) (blockHeader *bc.BlockHeader, err error) {
+	return bc.EncodeBlockHeaderStr("000000208e33a53195acad0ab42ddbdbe3e4d9ca081332e5b01a62e340dbd8167d1a787b702f61bb913ac2063e0f2aed6d933d3386234da5c8eb9e30e498efd25fb7cb96fff12c60ffff7f2001000000")
 }
 
 func TestVerifyMerkleProof(t *testing.T) {
@@ -31,9 +29,9 @@ func TestVerifyMerkleProof(t *testing.T) {
 			"391e62b3419d8a943f7dbc7bddc90e30ec724c033000dc0c8872253c27b03a42",
 		},
 	}
-	hcm := mockBlockHeaderChain{}
+	hcm := &mockBlockHeaderChain{}
 
-	spvc := bc.NewSPVClient(&hcm)
+	spvc, _ := bc.NewSPVClient(bc.WithBlockHeaderChain(hcm))
 
 	t.Run("JSON", func(t *testing.T) {
 		valid, isLastInTree, err := spvc.VerifyMerkleProofJSON(context.Background(), proofJSON)


### PR DESCRIPTION
Adding a new interface to the blockheader.go file to allow support fr returning both a strongly typed header or a header hash. Implementation used will likely depend on the header client the user is interfacing with.

Added functional options onto the SPVClient for providing a block header implementation.

Changed merkleproof verify code to use new BlockHeader method which will check both client implementations, if provided.

Renamed ToString to String and moved the old DecodeBlockHeader to the Bytes receiver method