### PR TITLE
Fix linter that runs during tests to work on linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# linter binary
+golangci-lint
+
 # Notes
 todo.md
 

--- a/.make/go.mk
+++ b/.make/go.mk
@@ -41,16 +41,10 @@ install-go: ## Install the application (Using Native Go)
 	@go install $(GIT_DOMAIN)/$(REPO_OWNER)/$(REPO_NAME)
 
 lint: ## Run the golangci-lint application (install if not found)
-	@#Travis (has sudo)
-	@if [ "$(shell command -v golangci-lint)" = "" ] && [ $(TRAVIS) ]; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.33.0 && sudo cp ./bin/golangci-lint $(go env GOPATH)/bin/; fi;
-	@#AWS CodePipeline
-	@if [ "$(shell command -v golangci-lint)" = "" ] && [ "$(CODEBUILD_BUILD_ID)" != "" ]; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0; fi;
-	@#Github Actions
-	@if [ "$(shell command -v golangci-lint)" = "" ] && [ "$(GITHUB_WORKFLOW)" != "" ]; then curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b $(go env GOPATH)/bin v1.33.0; fi;
-	@#Brew - MacOS
-	@if [ "$(shell command -v golangci-lint)" = "" ] && [ "$(shell command -v brew)" != "" ]; then brew install golangci-lint; fi;
+	@echo "downloading golangci-lint..."
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- v1.33.0
 	@echo "running golangci-lint..."
-	@golangci-lint run
+	@GOGC=20 ./bin/golangci-lint run
 
 test: ## Runs vet, lint and ALL tests
 	@$(MAKE) lint


### PR DESCRIPTION
"make test" does not work on linux, fixed by not depending on os when installing linter. 

Copied from a similar change in go-bk https://github.com/libsv/go-bk/commit/0e5966496ef624d0791d590ec529d2ee8b9d1378