### PR TITLE
Fix: Fee Verification for SPV

### DIFF
--- a/spv/ancestors_binary.go
+++ b/spv/ancestors_binary.go
@@ -149,6 +149,18 @@ func VerifyAncestors(ctx context.Context, ancestry *Ancestry, mpv MerkleProofVer
 	ancestors[paymentTxID] = &Ancestor{
 		Tx: ancestry.PaymentTx,
 	}
+	if opts.fees {
+		if opts.feeQuote == nil {
+			return ErrNoFeeQuoteSupplied
+		}
+		ok, err := ancestry.PaymentTx.IsFeePaidEnough(opts.feeQuote)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return ErrFeePaidNotEnough
+		}
+	}
 	for _, ancestor := range ancestors {
 		inputsToCheck := make(map[[32]byte]*extendedInput)
 		if len(ancestor.Tx.Inputs) == 0 {
@@ -203,27 +215,6 @@ func VerifyAncestors(ctx context.Context, ancestry *Ancestry, mpv MerkleProofVer
 				unlockingScript := input.UnlockingScript
 				if !verifyInputOutputPair(ancestor.Tx, lockingScript, unlockingScript) {
 					return ErrPaymentNotVerified
-				}
-			}
-		}
-		if opts.fees {
-			if opts.feeQuote == nil {
-				return ErrNoFeeQuoteSupplied
-			}
-			// no need to check fees for transactions we have proofs for
-			if ancestor.Proof == nil {
-				// add satoshi amounts to all inputs which correspond to outputs we have
-				for inputID, extendedInput := range inputsToCheck {
-					if ancestry.Ancestors[inputID] == nil {
-						return ErrCannotCalculateFeePaid
-					}
-					sats := ancestry.Ancestors[inputID].Tx.Outputs[extendedInput.input.PreviousTxOutIndex].Satoshis
-					ancestor.Tx.Inputs[extendedInput.vin].PreviousTxSatoshis = sats
-				}
-				// check the fees
-				ok, err := ancestor.Tx.IsFeePaidEnough(opts.feeQuote)
-				if err != nil || !ok {
-					return ErrFeePaidNotEnough
 				}
 			}
 		}


### PR DESCRIPTION
Currently, the ancestry verification verifies the paid fees of ancestors, instead of the payment tx. This fixes that.