### PR TITLE
feat(BUMP): implementation of NewBUMPFromStream that returns bytes used

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -336,7 +336,6 @@ linters:
     - revive
     - unconvert
     - dupl
-    - maligned
     - misspell
     - dogsled
     - prealloc
@@ -385,7 +384,6 @@ issues:
         - goconst
         - dupl
         - gosec
-        - maligned
         - lll
 
     # Exclude known linters from partially hard-vendored code,

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -239,9 +239,6 @@ linters-settings:
     line-length: 150
     # tab width in spaces. Default to 1.
     tab-width: 1
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.


### PR DESCRIPTION
### What has been done

A new function `NewBUMPFromStream` was created with the same functionality as `NewBUMPFromBytes`, except it returns a number of bytes used.

This was modelled on `NewTxFromStream` from [go-bt](https://pkg.go.dev/github.com/libsv/go-bt#NewTxFromStream).

The signature of `NewBUMPFromBytes` was untouched for backwards compatibility.

### Why?

In order to make it easier to parse BUMPs from BEEF and avoid repeating this parsing in SPV, go-bc and Arc :)