### PR TITLE
fix: BUMP txid leaf misplaced in Path[0] and nil deref in CalculateRootGivenTxid

### DIFF
--- a/bump.go
+++ b/bump.go
@@ -185,7 +185,8 @@ func (bump *BUMP) CalculateRootGivenTxid(txid string) (string, error) {
 	var index uint64
 	txidFound := false
 	for _, l := range bump.Path[0] {
-		if *l.Hash == txid {
+		// l.Hash is nil for duplicate leaves.
+		if l.Hash != nil && *l.Hash == txid {
 			txidFound = true
 			index = *l.Offset
 			break
@@ -248,7 +249,9 @@ func NewBUMPFromMerkleTreeAndIndex(blockHeight uint64, merkleTree []*chainhash.H
 		return bump, nil
 	}
 
-	oddTxIndex := false
+	// Only the parity of the leaf-level index decides on which side of its
+	// sibling the txid leaf belongs in Path[0].
+	oddTxIndex := txIndex&1 == 1
 
 	numOfTxids := (len(merkleTree) + 1) / 2
 	treeHeight := int(math.Log2(float64(numOfTxids)))
@@ -263,7 +266,6 @@ func NewBUMPFromMerkleTreeAndIndex(blockHeight uint64, merkleTree []*chainhash.H
 			offset++
 		} else {
 			// we need to use the hash to the left.
-			oddTxIndex = true
 			offset--
 		}
 		thisLeaf := leaf{Offset: &offset}

--- a/bump_test.go
+++ b/bump_test.go
@@ -219,3 +219,37 @@ func BenchmarkNewBUMPFromMerkleTreeAndIndex(b *testing.B) {
 		require.Equal(b, l, totalHashes)
 	}
 }
+
+// TestNewBUMPFromMerkleTreeEverySizeAndIndex covers every block size up to one
+// past a full 32-leaf tree, and every transaction position within each block.
+// It guards against the txid leaf being misplaced in Path[0] for blocks with
+// an odd number of transactions (offset flag accumulated across all levels
+// instead of taken from the leaf level), which made CalculateRootGivenTxid
+// dereference a nil hash on the duplicate leaf and panic.
+func TestNewBUMPFromMerkleTreeEverySizeAndIndex(t *testing.T) {
+	const maxBlockSize = 33
+
+	for blockSize := 1; blockSize <= maxBlockSize; blockSize++ {
+		chainHashBlock := make([]*chainhash.Hash, 0, blockSize)
+		for i := 0; i < blockSize; i++ {
+			var hashBytes [32]byte
+			hashBytes[0] = byte(i + 1)
+			hash, err := chainhash.NewHash(hashBytes[:])
+			require.NoError(t, err)
+			chainHashBlock = append(chainHashBlock, hash)
+		}
+		merkles := BuildMerkleTreeStoreChainHash(chainHashBlock)
+		expectedRoot := merkles[len(merkles)-1].String()
+
+		for txIndex := 0; txIndex < blockSize; txIndex++ {
+			txid := chainHashBlock[txIndex].String()
+
+			bump, err := NewBUMPFromMerkleTreeAndIndex(fakeMadeUpNum, merkles, uint64(txIndex))
+			require.NoErrorf(t, err, "blockSize=%d txIndex=%d", blockSize, txIndex)
+
+			root, err := bump.CalculateRootGivenTxid(txid)
+			require.NoErrorf(t, err, "blockSize=%d txIndex=%d", blockSize, txIndex)
+			require.Equalf(t, expectedRoot, root, "blockSize=%d txIndex=%d", blockSize, txIndex)
+		}
+	}
+}

--- a/bump_test.go
+++ b/bump_test.go
@@ -247,9 +247,51 @@ func TestNewBUMPFromMerkleTreeEverySizeAndIndex(t *testing.T) {
 			bump, err := NewBUMPFromMerkleTreeAndIndex(fakeMadeUpNum, merkles, uint64(txIndex))
 			require.NoErrorf(t, err, "blockSize=%d txIndex=%d", blockSize, txIndex)
 
+			// CalculateRootGivenTxid looks leaves up by offset, so it cannot
+			// detect misordering; assert the order explicitly.
+			for height, leaves := range bump.Path {
+				for i := 1; i < len(leaves); i++ {
+					require.Lessf(t, *leaves[i-1].Offset, *leaves[i].Offset,
+						"blockSize=%d txIndex=%d: leaves at height %d not ordered by offset", blockSize, txIndex, height)
+				}
+			}
+
 			root, err := bump.CalculateRootGivenTxid(txid)
 			require.NoErrorf(t, err, "blockSize=%d txIndex=%d", blockSize, txIndex)
 			require.Equalf(t, expectedRoot, root, "blockSize=%d txIndex=%d", blockSize, txIndex)
 		}
 	}
+}
+
+// TestNewBUMPFromMerkleTreeTxidLeafOrder pins the exact shape of the ordering
+// bug: for the last transaction at an even index of an odd-sized block, the
+// txid leaf must come first in Path[0], before its duplicate padding sibling.
+func TestNewBUMPFromMerkleTreeTxidLeafOrder(t *testing.T) {
+	const blockSize = 11
+	const txIndex = uint64(10)
+
+	chainHashBlock := make([]*chainhash.Hash, 0, blockSize)
+	for i := 0; i < blockSize; i++ {
+		var hashBytes [32]byte
+		hashBytes[0] = byte(i + 1)
+		hash, err := chainhash.NewHash(hashBytes[:])
+		require.NoError(t, err)
+		chainHashBlock = append(chainHashBlock, hash)
+	}
+	merkles := BuildMerkleTreeStoreChainHash(chainHashBlock)
+
+	bump, err := NewBUMPFromMerkleTreeAndIndex(fakeMadeUpNum, merkles, txIndex)
+	require.NoError(t, err)
+
+	levelZero := bump.Path[0]
+	require.Len(t, levelZero, 2)
+
+	require.NotNil(t, levelZero[0].Txid)
+	require.True(t, *levelZero[0].Txid)
+	require.Equal(t, txIndex, *levelZero[0].Offset)
+	require.Equal(t, chainHashBlock[txIndex].String(), *levelZero[0].Hash)
+
+	require.NotNil(t, levelZero[1].Duplicate)
+	require.True(t, *levelZero[1].Duplicate)
+	require.Equal(t, txIndex+1, *levelZero[1].Offset)
 }


### PR DESCRIPTION
## Bugs

**1. `NewBUMPFromMerkleTreeAndIndex` misplaces the txid leaf in `Path[0]`.**
The position of the txid leaf (before or after its sibling) is decided by an `oddTxIndex` flag that is set whenever the offset at *any* tree level is odd, instead of only the leaf level's parity. For a transaction at the last (even) index of a block with an odd transaction count, `Path[0]` comes out as `[duplicate, txid]` — the padding leaf first.

**2. `CalculateRootGivenTxid` panics on duplicate leaves.**
While searching `Path[0]` for the txid it dereferences each leaf's `Hash` without a nil check. A duplicate leaf has a nil `Hash`, so any BUMP shaped as above (or any malformed BUMP with a duplicate leaf first) causes a nil-pointer panic.

## Reproduction

Any block with an odd number of transactions, requesting the BUMP for the transaction at the last (even) index — e.g. an 11-tx block, tx index 10. Construction misorders the path; verification then segfaults. Found in production: ARC (Teranode) block processing crash-looped on such blocks, and the malformed BUMPs it had already stored crashed downstream consumers on parse-and-verify.

## Fixes

- Derive `oddTxIndex` from `txIndex&1` before the level loop (leaf-level parity only).
- Nil-check `l.Hash` in the txid search loop — this also protects consumers verifying previously-produced malformed BUMPs.

## Test

`TestNewBUMPFromMerkleTreeEverySizeAndIndex`: every block size up to 33 transactions × every transaction index, each BUMP verified via `CalculateRootGivenTxid` against the root from `BuildMerkleTreeStoreChainHash`. Panics with the nil deref on current master; passes with the fixes. Full existing suite passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)